### PR TITLE
Add spend recommend algorithm

### DIFF
--- a/pages/api/spendrec.js
+++ b/pages/api/spendrec.js
@@ -1,0 +1,25 @@
+import spendingData from "../../data/spendingData.json";
+
+const sortedByWeekday = Array.from({ length: 7 }, (_, weekday) =>
+  spendingData.filter((d) => new Date(d.time).getDay() === weekday)
+);
+
+function habitAnalysis(weekday) {
+  // monday is 0, sunday is 6
+  const averageWeekdayAmount = +(
+    sortedByWeekday[weekday].map((e) => e.amount).reduce((x, y) => x + y) /
+    sortedByWeekday[weekday].length
+  ).toFixed(2);
+
+  return {
+    amount: averageWeekdayAmount,
+  };
+}
+
+export default function handler(req, res) {
+  const date = req.query.date ? new Date(res.query.date) : new Date();
+
+  res.status(200).json(habitAnalysis(date.getDay()));
+}
+
+console.log(habitAnalysis(0));

--- a/pages/api/spendrec.js
+++ b/pages/api/spendrec.js
@@ -21,5 +21,3 @@ export default function handler(req, res) {
 
   res.status(200).json(habitAnalysis(date.getDay()));
 }
-
-console.log(habitAnalysis(0));


### PR DESCRIPTION
Call `/api/spendrec` with the optional parameter `?date=2022-02-10`

Returns an object currently only representing the amount recommended
```
{
  amount: float;
}
```

Formula:
 - average of spending on that weekday in all history (e.g., average spending every monday)