### PR TITLE
Add specialised date API

### DIFF
--- a/pages/api/calendarcolor.js
+++ b/pages/api/calendarcolor.js
@@ -1,0 +1,45 @@
+import spendingData from "../../data/spendingData.json";
+
+const UPPER_STDEV_BOUND_TO_COLOR = [
+  { stdev: -2, descriptor: "very little" },
+  { stdev: -1, descriptor: "little" },
+  { stdev: 1, descriptor: "medium" },
+  { stdev: 9999999999, descriptor: "large" },
+];
+
+function calculateStats(numArray) {
+  const mean = numArray.reduce((s, n) => s + n) / numArray.length;
+  const variance =
+    numArray.reduce((s, n) => s + (n - mean) ** 2, 0) / (numArray.length - 1);
+  return { mean, stdev: Math.sqrt(variance) };
+}
+
+const allDays = [
+  ...new Set(spendingData.map((i) => i.time.substring(0, i.time.indexOf("T")))),
+]; // remove duplicates and convert to array to use map
+
+const sumPurchasesOnDate = {};
+for (const d of allDays) {
+  sumPurchasesOnDate[d] = spendingData
+    .filter((i) => i.time.startsWith(d))
+    .map((i) => i.amount)
+    .reduce((a, b) => a + b);
+}
+
+const { mean, stdev } = calculateStats(Object.values(sumPurchasesOnDate));
+
+export default function handler(req, res) {
+  const date = req.query.date ?? new Date().toISOString().split("T")[0];
+  for (const [index, val] of UPPER_STDEV_BOUND_TO_COLOR.entries()) {
+    if (mean + stdev * val.stdev > sumPurchasesOnDate[date]) {
+      return res.status(200).json({
+        descriptor: val.descriptor,
+        severity: index,
+        spending: sumPurchasesOnDate[date],
+        mean,
+        stdev,
+      });
+    }
+  }
+  res.status(200).json([]);
+}

--- a/pages/api/calendarcolor.js
+++ b/pages/api/calendarcolor.js
@@ -1,6 +1,8 @@
 import spendingData from "../../data/spendingData.json";
 
 const UPPER_STDEV_BOUND_TO_COLOR = [
+  // e.g., if spending is less than 1 stdev below the mean
+  // but more than 2 stdevs it will return "little"
   { stdev: -2, descriptor: "very little", color: "#ffffff" },
   { stdev: -1, descriptor: "little", color: "#ceb7ff" },
   { stdev: 1, descriptor: "medium", color: "#e9effd" },

--- a/pages/api/calendarcolor.js
+++ b/pages/api/calendarcolor.js
@@ -38,8 +38,6 @@ export default function handler(req, res) {
         ...val,
         severity: index,
         spending: sumPurchasesOnDate[date],
-        mean,
-        stdev,
       });
     }
   }

--- a/pages/api/calendarcolor.js
+++ b/pages/api/calendarcolor.js
@@ -1,10 +1,10 @@
 import spendingData from "../../data/spendingData.json";
 
 const UPPER_STDEV_BOUND_TO_COLOR = [
-  { stdev: -2, descriptor: "very little" },
-  { stdev: -1, descriptor: "little" },
-  { stdev: 1, descriptor: "medium" },
-  { stdev: 9999999999, descriptor: "large" },
+  { stdev: -2, descriptor: "very little", color: "#ffffff" },
+  { stdev: -1, descriptor: "little", color: "#ceb7ff" },
+  { stdev: 1, descriptor: "medium", color: "#e9effd" },
+  { stdev: 9999999999, descriptor: "large", color: "#3559ff" },
 ];
 
 function calculateStats(numArray) {
@@ -33,7 +33,7 @@ export default function handler(req, res) {
   for (const [index, val] of UPPER_STDEV_BOUND_TO_COLOR.entries()) {
     if (mean + stdev * val.stdev > sumPurchasesOnDate[date]) {
       return res.status(200).json({
-        descriptor: val.descriptor,
+        ...val,
         severity: index,
         spending: sumPurchasesOnDate[date],
         mean,


### PR DESCRIPTION
`GET /api/calendarcolor?date=2022-02-18`
If `date` is not provided, assume the current day.

Report total spending, "severity" (num from 0-3 from "very little", "little", "medium", "large"), descriptor for debugging severity, and the colour for the dashboard for that day. Can be extended or reduced as needed, this is quite flexible.

Severity is calculated by the number of standard deviations that day's spending was compared to the total mean.

Relevant:
```js
const UPPER_STDEV_BOUND_TO_COLOR = [
  // e.g., if spending is less than 1 stdev below the mean
  // but more than 2 stdevs it will return "little"
  { stdev: -2, descriptor: "very little", color: "#ffffff" },
  { stdev: -1, descriptor: "little", color: "#ceb7ff" },
  { stdev: 1, descriptor: "medium", color: "#e9effd" },
  { stdev: 9999999999, descriptor: "large", color: "#3559ff" },
]
```

It appears that some of these APIs may want to be merged later on to avoid code duplication.